### PR TITLE
Ryan video player fix

### DIFF
--- a/AirAssaultHome.js
+++ b/AirAssaultHome.js
@@ -541,7 +541,7 @@ export function VideoScreen({ navigation, route }) {
       />
       </View>
       {/* Display video button with an array of video links */}
-        <VideoButton videoLinks={filteredData} />
+        <VideoButton videoLinks={filteredData} currentVideoID={null} />
       <View style={{ marginBottom: 30 }}></View>
     </ScrollView>
   );
@@ -561,7 +561,7 @@ export function PlaylistScreen({ navigation, route }) {
       <View style={{ alignItems: 'center', backgroundColor: "#221f20", height: 45, borderTopWidth: 5, borderBottomWidth: 3, borderColor: "#ffcc01" }}>
         <Text style={{ color: "#FFFFFF", fontSize: 20 }} variant='headlineLarge'>{screen}</Text>
       </View>
-      <VideoButton videoLinks={playlistVideoLinks} /> 
+      <VideoButton videoLinks={playlistVideoLinks} currentVideoID={null} /> 
     </ScrollView>
   );
 }

--- a/VideoButton.js
+++ b/VideoButton.js
@@ -1,11 +1,12 @@
 import React, { useState, useCallback, useRef } from 'react';
-import { StyleSheet, View, Image, TouchableOpacity, Text, Linking, ScrollView , Alert, Button} from 'react-native';
+import { StyleSheet, View, Image, TouchableOpacity, Text, Linking, ScrollView , Alert, Button, Dimensions} from 'react-native';
 import {IconButton} from 'react-native-paper'
 import { AddedVideosContext } from './videoContext';
 import { useNavigation } from '@react-navigation/native';
 import { useRoute } from '@react-navigation/native';
 import YoutubePlayer from "react-native-youtube-iframe";
 
+const screenDimension = Dimensions.get("screen")
 const styles = StyleSheet.create(
   {
     container: {
@@ -37,23 +38,24 @@ const styles = StyleSheet.create(
   },
   }
 )
-const VideoComp = ({video,  handleAddToPlaylist, addedVideos}) => {
+const VideoComp = ({video,  handleAddToPlaylist, addedVideos, videoLinks, currentVideoID}) => {
   const navigation = useNavigation();
-   
+  
    return ( 
         <View>
        <View style={styles.videoCard}>
-            {/* <YoutubePlayer
-                height={'100%'}
-                width={340}
-                play={playing}
-                videoId={video.id}
-                /> */}
-                <TouchableOpacity onPress={() => navigation.navigate('Video Player', {id: video.id, 
-      description: video.description, 
-      title: video.title,
-      handleAddToPlaylist,
-      addedVideos})} style={{ marginTop: -45, width: 345, alignSelf: 'center' }}>
+             
+                <TouchableOpacity onPress={() => {
+                  // navigation push will cause previous videos to continue playing and navigate just doesnt work
+                  // replace will replace the current stack with new, if navigating from video hub -> video player
+                  // pressing back will go to air assault home sicne video hub will be replaced by video player stack 
+                  // if want to avoid this, can modify back button or figure out how to auto pause videos when using push
+                  navigation.replace('Video Player', {id: video.id, 
+                  description: video.description, 
+                  title: video.title,
+                  link: video.link,
+                  handleAddToPlaylist,
+                  addedVideos, videoLinks, currentVideoID})}} style={{ marginTop: -45, width: 345, alignSelf: 'center' }}>
             <Image
               source={{ uri: `https://img.youtube.com/vi/${video.link.split('v=')[1]}/0.jpg` }}
               style={{ marginTop: 10, width: 345, height: 290, alignSelf: 'center', borderTopLeftRadius: 8, borderBottomRightRadius: 8 }}
@@ -80,12 +82,20 @@ const VideoComp = ({video,  handleAddToPlaylist, addedVideos}) => {
  
 }
 export const VideoPlayerScreen = ({navigation, route}) =>{
-  const {id, description, title} = route.params;
+  const {id, description, title, videoLinks, addedVideos, handleAddToPlaylist, link} = route.params;
   const [playing, setPlaying] = useState(false);
   const screen = route.name;
   const [showDescription, setShowDescription] = useState(false);
+  const resolution = 9/16;
+  const video = {link, id, description, title}; // create video item for playlist button
   const showDesc = () =>{
     setShowDescription(!showDescription);
+  }
+  // used to rerender the remove from / add to playlist button
+  const[isAdded, setIsAdded] = useState(!!addedVideos[link]);
+  const handleAdd = (video) => {
+    handleAddToPlaylist(video);
+    setIsAdded(!isAdded);
   }
   return (
     
@@ -96,17 +106,34 @@ export const VideoPlayerScreen = ({navigation, route}) =>{
      <View style ={{marginTop: 50, justifyContent: 'center', alignItems:'center'}} >
       <YoutubePlayer
         stlye={{  width:'100%', }}
-        height={200}
-        width={340}
+        height={resolution*(screenDimension.height)}
+        width={resolution*(screenDimension.width)}
         play={playing}
         videoId={id}
                 />
-      <View style = {{backgroundColor: '#ffcc01', borderTopRightRadius: 5,borderTopLeftRadius: 5,borderBottomLeftRadius: 5, borderBottomRightRadius: 5}}>
+      <View style={{width: resolution*(screenDimension.width), justifyContent: 'space-between', flexDirection: 'row', backgroundColor: '#ffcc01', borderBottomLeftRadius: 5, borderBottomRightRadius: 5}} >
+        <Text style={{ fontSize: 16, fontWeight: 'bold', alignSelf: 'center', padding: 8, flexDirection: 'start' }}>
+                {title}
+      </Text>
+    <TouchableOpacity onPress={() => handleAdd(video)}  style={{ flexDirection: 'row', alignItems: 'center' }}>
+    <Text style={{ fontSize: 16, fontWeight: 'bold', alignSelf: 'center', padding: 5 }}>
+                  { isAdded ? 'Remove from' :'Add to'}</Text>
+      <IconButton
+      icon="playlist-play"
+      size={20}
+      color="#000000"
+    />
+          </TouchableOpacity>
+           </View>
+      <View style = {{width: resolution*(screenDimension.width),backgroundColor: '#ffcc01', borderTopRightRadius: 5,borderTopLeftRadius: 5,borderBottomLeftRadius: 5, borderBottomRightRadius: 5}}>
       <TouchableOpacity onPress={showDesc}  style={{ flexDirection: 'row', alignItems: 'center' }}>
     <Text style={{ fontSize: 16, fontWeight: 'bold', alignSelf: 'center', padding: 5 }}>
                 { showDescription ? 'Hide Description' :'Show Description'}</Text>
       </TouchableOpacity>
       {showDescription &&  <Text> {description}</Text> }
+      </View>
+      <View>
+        <VideoButton videoLinks={videoLinks} currentVideoID={id}/>
       </View>
     </View>
   </ScrollView>
@@ -114,13 +141,10 @@ export const VideoPlayerScreen = ({navigation, route}) =>{
   );
 }
  
-const VideoButton = ({ videoLinks }) => {
-
-   
-   
+const VideoButton = ({ videoLinks, currentVideoID }) => {
 
   const { addedVideos, setAddedVideos } = React.useContext(AddedVideosContext);
-
+  const otherVideos = videoLinks.filter(video => video.id !== currentVideoID);
   const handleVideoPress = (video) => {
     // Open YouTube app or browser with the video link
     Linking.openURL(video.link);
@@ -140,10 +164,12 @@ const VideoButton = ({ videoLinks }) => {
      
      <View style ={styles.container}>
        
-         {videoLinks.map((video) => (
+         {otherVideos.map((video) => (
           <VideoComp key={video.id} video={video}
           handleAddToPlaylist={handleAddToPlaylist} 
           addedVideos={addedVideos}
+          videoLinks={videoLinks}
+          currentVideoID = {currentVideoID}
           />
          ))}
     </View>


### PR DESCRIPTION
Fixed screen size, added video title and playlist button like video hub screen, changed description button format, added videos underneath current playing video. 

An important note, changed the navigation to video player to a replace instead of navigation or push. Push worked to navigate to new video when clicking on a video while already on video player ,however, previous videos would still play if you dont manually pause it. There probably is a way to fix it but I used navigation.replace. This will replace the current stack of the navigation, so when you initially click a video, it will replace the video hub stack with the new video player screen, if you were to press back it will take you to the stack previous to video hub which will be the air assault screen. This can be annoying so if you can try to fix it please do since I think the stack will work well when going back to previous videos. 